### PR TITLE
Reparer branche cassée et corriger fuseau horaire

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,10 +5,10 @@ export function Header({ currentTime }: { currentTime: Date }) {
     <div className="flex justify-between items-center">
       <div className="flex flex-col items-start">
         <div className="text-2xl font-bold text-foreground">
-          {currentTime.toLocaleTimeString("fr-FR")}
+          {currentTime.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit", timeZone: "Europe/Paris" })}
         </div>
         <div className="text-sm text-muted-foreground">
-          {currentTime.toLocaleDateString("fr-FR")}
+          {currentTime.toLocaleDateString("fr-FR", { timeZone: "Europe/Paris" })}
         </div>
       </div>
       <h1 className="text-3xl font-semibold">My-EpiRooms</h1>

--- a/components/activity-panel/daily-activities.tsx
+++ b/components/activity-panel/daily-activities.tsx
@@ -29,6 +29,7 @@ export function DailyActivities({ activities }: DailyActivitiesProps) {
                     {activity.start.toLocaleTimeString("fr-FR", {
                       hour: "2-digit",
                       minute: "2-digit",
+                      timeZone: "Europe/Paris",
                     })}
                   </time>{" "}
                   -{" "}
@@ -39,6 +40,7 @@ export function DailyActivities({ activities }: DailyActivitiesProps) {
                     {activity.end.toLocaleTimeString("fr-FR", {
                       hour: "2-digit",
                       minute: "2-digit",
+                      timeZone: "Europe/Paris",
                     })}
                   </time>
                 </span>


### PR DESCRIPTION
Fix build by removing unused import and correct time display by enforcing `Europe/Paris` timezone.

This PR resolves an ESLint error preventing the build and addresses a 1-2 hour time offset issue by explicitly setting the `Europe/Paris` timezone for all date and time displays. The responsive requirement to hide the map on mobile was already met.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bac866c-0080-4e3c-957d-e2b4ca7291b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bac866c-0080-4e3c-957d-e2b4ca7291b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

